### PR TITLE
move debian dependency

### DIFF
--- a/silver_platter/__init__.py
+++ b/silver_platter/__init__.py
@@ -23,7 +23,6 @@ import breezy.bzr  # For bzr support   # noqa: F401
 import breezy.plugins.launchpad  # For lp: URL support  # noqa: F401
 import breezy.plugins.gitlab  # For gitlab support  # noqa: F401
 import breezy.plugins.github  # For github support  # noqa: F401
-import breezy.plugins.debian  # For apt: URL support  # noqa: F401
 
 __version__ = (0, 4, 9)
 version_string = ".".join(map(str, __version__))

--- a/silver_platter/debian/__init__.py
+++ b/silver_platter/debian/__init__.py
@@ -34,6 +34,7 @@ from breezy.bzr import RemoteBzrProber
 from breezy.git import RemoteGitProber
 from breezy.git.repository import GitRepository
 from breezy.mutabletree import MutableTree
+import breezy.plugins.debian  # For apt: URL support  # noqa: F401
 from breezy.plugins.debian.cmds import cmd_builddeb
 from breezy.plugins.debian.directory import (
     source_package_vcs,


### PR DESCRIPTION
Move dependency on debian plugin to debian module.

I watched your talk about Debian janitor and it's ability to put up pull requests and was quite excited to try out silver-platter, but i can't get it to run, and when i try to find the module `breezy.plugins.debian` it doesn't seem to exist as part of the breezy upstream or as part of the package released on PYPI?

```
Traceback (most recent call last):
  File "/Users/rsim/Code/zendesk/silver-platter/.direnv/python-3.10.2/bin/svp", line 33, in <module>
    sys.exit(load_entry_point('silver-platter', 'console_scripts', 'svp')())
  File "/Users/rsim/Code/zendesk/silver-platter/.direnv/python-3.10.2/bin/svp", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/Users/rsim/.asdf/installs/python/3.10.2/lib/python3.10/importlib/metadata/__init__.py", line 162, in load
    module = import_module(match.group('module'))
  File "/Users/rsim/.asdf/installs/python/3.10.2/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/rsim/Code/zendesk/silver-platter/silver_platter/__init__.py", line 26, in <module>
    import breezy.plugins.debian  # For apt: URL support  # noqa: F401
ModuleNotFoundError: No module named 'breezy.plugins.debian'
```

my pip freeze output is 

```
breezy==3.2.2
certifi==2021.10.8
cffi==1.15.0
charset-normalizer==2.0.12
configobj==5.0.6
Deprecated==1.2.13
distro==1.7.0
dulwich==0.20.35
fastbencode==0.0.7
flake8==4.0.1
httplib2==0.20.4
idna==3.3
importlib-metadata==4.11.3
Jinja2==3.1.1
keyring==23.5.0
launchpadlib==1.10.16
lazr.restfulclient==0.14.4
lazr.uri==1.0.6
MarkupSafe==2.1.1
mccabe==0.6.1
oauthlib==3.2.0
patiencediff==0.2.2
pycodestyle==2.8.0
pycparser==2.21
pyflakes==2.4.0
PyGithub==1.55
PyJWT==2.3.0
PyNaCl==1.5.0
pyparsing==3.0.8
PyYAML==6.0
requests==2.27.1
-e git+ssh://git@github.com/russell/silver-platter.git@0f0bd9b5a4677b929a6869855d631f11e3ddc18f#egg=silver_platter
six==1.16.0
urllib3==1.26.9
wadllib==1.3.6
wrapt==1.14.0
zipp==3.8.0
```

Perhaps we can just move it to the debian module so that it's not loaded if running the `debian-svp` command?