### PR TITLE
add launchpadlib dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'breezy>=3.2.0',
         'dulwich>=0.20.23',
         'jinja2',
+        'launchpadlib',
     ],
     extras_require={
         'debian': debian_deps,


### PR DESCRIPTION
when running `svp login https://github.com` i got an error about missing dependencies

```
Traceback (most recent call last):
  File "/Users/rsim/Code/zendesk/silver-platter/.direnv/python-3.10.2/bin/svp", line 33, in <module>
    sys.exit(load_entry_point('silver-platter', 'console_scripts', 'svp')())
  File "/Users/rsim/Code/zendesk/silver-platter/silver_platter/__main__.py", line 137, in main
    return subcommands[args.subcommand](rest)
  File "/Users/rsim/Code/zendesk/silver-platter/silver_platter/__main__.py", line 48, in login_main
    from launchpadlib import uris as lp_uris
ModuleNotFoundError: No module named 'launchpadlib'
```
