### PR TITLE
add pyyaml dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         'breezy>=3.2.0',
         'dulwich>=0.20.23',
         'jinja2',
+        'pyyaml',
     ],
     extras_require={
         'debian': debian_deps,


### PR DESCRIPTION
when trying to use a yaml recipe example from the readme, it errors without manually install pyyaml first, i don't do much python, or know what defacto yaml library is, but i could get around this by installing pyyaml.

```
(python-3.10.2) $ svp run --mode=propose --recipe=the-white-glove/test.yml https://github.com/zendesk/test-project
Traceback (most recent call last):
  File "/Users/rsim/Code/zendesk/silver-platter/.direnv/python-3.10.2/bin/svp", line 33, in <module>
    sys.exit(load_entry_point('silver-platter', 'console_scripts', 'svp')())
  File "/Users/rsim/Code/zendesk/silver-platter/silver_platter/__main__.py", line 137, in main
    return subcommands[args.subcommand](rest)
  File "/Users/rsim/Code/zendesk/silver-platter/silver_platter/run.py", line 216, in main
    from .recipe import Recipe
  File "/Users/rsim/Code/zendesk/silver-platter/silver_platter/recipe.py", line 21, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```
