### PR TITLE
Also support slightly older versions of breezy 3.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages =
     silver_platter.debian
     silver_platter.tests
 install_requires =
-    breezy>=3.3.0
+    breezy>=3.3.0.dev.0
     dulwich>=0.20.23
     jinja2
     pyyaml


### PR DESCRIPTION
Also support slightly older versions of breezy 3.3.0.
