### PR TITLE
Install python-debian from git

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,8 @@ console_scripts =
 [options.extras_require]
 debian =
     debmutate>=0.3
-    python_debian
+    # Install from git until the fix for #1018822 makes it into pypi
+    python_debian@git+https://salsa.debian.org/python-debian-team/python-debian
     brz-debian@git+https://github.com/breezy-team/breezy-debian
 launchpad = launchpadlib
 detect-gbp-dch =  lintian-brush


### PR DESCRIPTION
Install python-debian from git

workaround for #1018822
