### PR TITLE
Rely on regular brz-debian, rather than the one from git

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ tests_require =
     testtools
     debmutate>=0.3
     python-debian
-    brz-debian@git+https://github.com/breezy-team/breezy-debian
+    brz-debian
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Rely on regular brz-debian, rather than the one from git.
