### PR TITLE
Use clearer unittest functions

### DIFF
--- a/silver_platter/tests/test_proposal.py
+++ b/silver_platter/tests/test_proposal.py
@@ -29,7 +29,7 @@ class WorkspaceTests(TestCaseWithTransport):
     def test_simple(self):
         b = self.make_branch("target")
         with Workspace(b, dir=self.test_dir) as ws:
-            self.assertIs(ws.resume_branch, None)
+            self.assertIsNone(ws.resume_branch)
             self.assertFalse(ws.changes_since_main())
             self.assertFalse(ws.changes_since_base())
             ws.local_tree.commit("foo")

--- a/silver_platter/tests/test_utils.py
+++ b/silver_platter/tests/test_utils.py
@@ -74,7 +74,7 @@ class TemporarySproutTests(TestCaseWithTransport):
 class RunPreCheckTests(TestCaseWithTransport):
     def test_none(self):
         tree = self.make_branch_and_tree("tree")
-        self.assertIs(run_pre_check(tree, None), None)
+        self.assertIsNone(run_pre_check(tree, None))
 
     def test_false(self):
         tree = self.make_branch_and_tree("tree")
@@ -82,13 +82,13 @@ class RunPreCheckTests(TestCaseWithTransport):
 
     def test_true(self):
         tree = self.make_branch_and_tree("tree")
-        self.assertIs(run_pre_check(tree, "/bin/true"), None)
+        self.assertIsNone(run_pre_check(tree, "/bin/true"))
 
 
 class RunPostCheckTests(TestCaseWithTransport):
     def test_none(self):
         tree = self.make_branch_and_tree("tree")
-        self.assertIs(run_post_check(tree, None, None), None)
+        self.assertIsNone(run_post_check(tree, None, None))
 
     def test_false(self):
         tree = self.make_branch_and_tree("tree")
@@ -101,4 +101,4 @@ class RunPostCheckTests(TestCaseWithTransport):
     def test_true(self):
         tree = self.make_branch_and_tree("tree")
         cid = tree.commit("a")
-        self.assertIs(run_post_check(tree, "/bin/true", since_revid=cid), None)
+        self.assertIsNone(run_post_check(tree, "/bin/true", since_revid=cid))


### PR DESCRIPTION
reformatted silver_platter/tests/test_proposal.py
reformatted silver_platter/tests/test_utils.py
All done! 2 reformatted, 8 left unchanged
