### PR TITLE
README: Full path to GitHub for logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Silver-Platter
 
-<img src="logo.png" alt="Silver-Platter logo" align="center" width="200px"/>
+<img src="https://github.com/jelmer/silver-platter/blob/master/logo.png" alt="Silver-Platter logo" align="center" width="200px"/>
 
 Silver-Platter makes it possible to contribute automatable changes to source
 code in a version control system


### PR DESCRIPTION
On [PyPi, silver-platter](https://pypi.org/project/silver-platter/) is using the same README as GitHub.

However, the logo isn't shown (gives HTTP 404 request in network tab)
This links it direct to GitHub.